### PR TITLE
Read contents of _ch.txt

### DIFF
--- a/remaster/autoinstall-user-data-fixed
+++ b/remaster/autoinstall-user-data-fixed
@@ -1,0 +1,47 @@
+#cloud-config
+autoinstall:
+  version: 1
+  
+  # Interactive sections - user can configure these
+  interactive-sections:
+    - locale
+    - keyboard
+    - network
+    - proxy
+    - storage
+    - identity
+    - ubuntu-pro
+    - drivers
+  
+  # Explicitly configure proxy section to use full interactive mode
+  proxy: ~
+  
+  # Don't configure apt at all - let installer handle mirrors naturally
+  # This prevents autoinstall from interfering with proxy/mirror testing
+  apt:
+    disable_components: []
+    preserve_sources_list: true
+  
+  # Force minimal server installation
+  source:
+    id: ubuntu-server-minimal
+    search_drivers: true
+  
+  # Force these specific values (should skip their screens entirely)  
+  ssh:
+    install-server: false
+    allow-pw: false
+    authorized-keys: []
+    
+  snaps: []
+  
+  # Use source selection instead of packages
+  packages: []
+  
+  updates: security
+  
+  # Simple cleanup after installation
+  late-commands:
+    - echo "AUTOINSTALL SUCCESS - SSH disabled, minimal server installed" > /target/var/log/autoinstall-success.log
+    
+  shutdown: reboot

--- a/remaster/grub-autoinstall-fixed.cfg
+++ b/remaster/grub-autoinstall-fixed.cfg
@@ -1,0 +1,20 @@
+set timeout=30
+set default=0
+
+menuentry "Install Ubuntu Server (Semi-Automated)" {
+    set gfxpayload=keep
+    linux /casper/vmlinuz autoinstall ds=nocloud;s=file:///cdrom/server/ console=tty0 console=ttyS0,115200n8
+    initrd /casper/initrd
+}
+
+menuentry "Install Ubuntu Server (Manual)" {
+    set gfxpayload=keep
+    linux /casper/vmlinuz
+    initrd /casper/initrd
+}
+
+menuentry "Try Ubuntu Server without installing" {
+    set gfxpayload=keep
+    linux /casper/vmlinuz
+    initrd /casper/initrd
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Address a UI issue in the custom semi-autoinstaller's proxy configuration screen.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The proxy configuration screen in the custom semi-autoinstaller is currently bare and lacks the expected display area for proxy mirror test results. This prevents users from seeing the outcome of the mirror connectivity test, which should occur on the same screen after proxy configuration. This PR aims to identify and correct the autoinstall configuration or UI elements causing this display issue.